### PR TITLE
change gem install to bundle install in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An implementation of the Relay.js example app, delivered by rails and the asset 
 # Setup
 
 * `npm install`
-* `gem install`
+* `bundle install`
 * `rake db:migrate`
 * `rails s`
 


### PR DESCRIPTION
I'm guessing just a typo!

```
rails-graphql-relay|master ⇒ gem install
ERROR:  While executing gem ... (Gem::CommandLineError)
    Please specify at least one gem name (e.g. gem build GEMNAME)
```